### PR TITLE
🐜修复回到主站的链接

### DIFF
--- a/controller/course.go
+++ b/controller/course.go
@@ -249,7 +249,7 @@ func CourseUploadLog(c *gin.Context) {
 var readme_template = `
 # BIT101 %v 课程共享资料
 > 课程编号：%v
-本页面由[BIT101](%v)维护，[点击查找 %v 课程及评价](%v/#/course/?search=%v)
+本页面由[BIT101](%v)维护，[点击查找 %v 课程及评价](%v/course/?search=%v)
 ## 类别说明
 * 书籍(book)：教科书、课程相关电子书等
 * 课件(ppt)：PPT什么的


### PR DESCRIPTION
现在不用 hash `#` 路由了。

## 例子

1. 访问 [BIT101 科学与工程计算 课程共享资料 | BIT101 Drive](https://onedrive.bit101.cn/zh-CN/course/%E7%A7%91%E5%AD%A6%E4%B8%8E%E5%B7%A5%E7%A8%8B%E8%AE%A1%E7%AE%97-100300010/)
2. [点击查找 科学与工程计算 课程及评价](https://bit101.cn/#/course/?search=100300010)

## 2024年10月16日更新

https://github.com/BIT101-dev/BIT101/pull/41 已经合并了，所以不改也可以。