### PR TITLE
🐛针对新统一认证需要手机验证码这件事进行提示

### DIFF
--- a/api/service/user.go
+++ b/api/service/user.go
@@ -251,7 +251,11 @@ func (s *UserService) WebvpnVerifyInit(sid string) (data webvpn.InitLoginReturn,
 func (s *UserService) WebvpnVerify(sid string, salt string, pwd string, execution string, cookie string, captcha string) (token string, code string, err error) {
 	err = webvpn.Login(sid, salt, pwd, execution, cookie, captcha)
 	if err != nil {
-		return "", "", errors.New("统一身份认证失败Orz")
+		if err == webvpn.ErrSMSCodeNeeded {
+			return "", "", webvpn.ErrSMSCodeNeeded
+		} else {
+			return "", "", errors.New("统一身份认证失败Orz")
+		}
 	}
 	//生成验证码
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/pkg/webvpn/login.go
+++ b/pkg/webvpn/login.go
@@ -16,6 +16,7 @@ import (
 )
 
 var ErrCookieInvalid = errors.New("未通过统一身份认证Orz")
+var ErrSMSCodeNeeded = errors.New("webvpn登陆需要手机验证码Orz")
 
 // 登录初始化返回结构
 type InitLoginReturn struct {
@@ -57,6 +58,9 @@ func Login(username string, salt string, password string, execution string, cook
 	}, map[string]string{"Cookie": cookie})
 	if err != nil || res.Code != 200 || strings.Contains(res.Text, "帐号登录或动态码登录") {
 		return errors.New("webvpn login error")
+	}
+	if strings.Contains(res.Text, "短信验证码") {
+		return ErrSMSCodeNeeded
 	}
 	return nil
 }


### PR DESCRIPTION
BIT 采用了新的统一身份认证，该统一身份认证会在特定条件下，需要用户输入手机验证码进行二次验证。

在原有的代码中，跳转到需要手机验证码的页面后会直接判定为登陆成功。导致成绩查询等模块出现登陆成功但无法查询到成绩的现象。这个问题遇到的人很多，在反馈箱 https://bit101.cn/paper/25 中，话廊中 https://bit101.cn/gallery/10760 均有提及，我在话廊 https://bit101.cn/gallery/10752 给出了解决方法。

然而，添加短信验证码一事较为复杂。此外，有些同学绑定了手机号，可收到短信验证码；有同学没绑定手机号，无法完成二次登陆。因此，本 commit 所做的只是在需要手机验证码的时候返回一个新的 Error，以供前端特判。